### PR TITLE
Fix class collections not updating

### DIFF
--- a/backend/DTO/GeoSpatialQueryTO.cs
+++ b/backend/DTO/GeoSpatialQueryTO.cs
@@ -1,4 +1,5 @@
 ﻿using NetTopologySuite.Geometries;
+using System.ComponentModel.DataAnnotations;
 
 namespace SmartContractVehicle.DTO
 {
@@ -6,6 +7,7 @@ namespace SmartContractVehicle.DTO
     {
         public required Point UserLocation { get; set; }
 
+        [Range(0, 10_000_000_000)] // Distance is probably calculated in meters
         public required double MaxDistance { get; set; }
 
         public string[]? AllowedManufactures { get; set; }
@@ -18,13 +20,18 @@ namespace SmartContractVehicle.DTO
 
         public string[]? AllowedDrivetrains { get; set; }
 
+        [Range(0, 1_000)] // This reach is given in km
         public double? MinRemainingReach { get; set; }
 
+        [Range(1, 150)] //  Means you can have a motorbike or a large bus
         public int? MinSeats { get; set; }
-
+        [Range(1, 150)] //  Means you can have a motorbike or a large bus
         public int? MaxSeats { get; set; }
 
+        [Range(0, 5)] // If you pay more than 5€ per Minute we have a Problem
         public double? MinPricePerMinute { get; set; }
+
+        [Range(0, 5)] // If you pay more than 5€ per Minute we have a Problem
         public double? MaxPricePerMinute { get; set; }
     }
 }

--- a/backend/Data/DbInitializer.cs
+++ b/backend/Data/DbInitializer.cs
@@ -55,7 +55,6 @@ namespace SmartContractVehicle.Data
                 {
                     Id = Guid.NewGuid(),
                     Name = brands[b],
-                    Models = [],
                     ImagePath = $"images/{brands[b].ToLower()}.png"
                 };
 
@@ -66,7 +65,6 @@ namespace SmartContractVehicle.Data
                         Id = Guid.NewGuid(),
                         Name = modelNames[b][m],
                         Producer = company,
-                        Trims = new List<VehicleTrim>()
                     };
 
                     for (int t = 0; t < trimNames[b][m].Length; t++)
@@ -79,7 +77,6 @@ namespace SmartContractVehicle.Data
                             Fuel = fuels[random.Next(0, fuels.Length)], // z. B. 0: Electric, 1: Diesel
                             Drivetrain = drivetrains[random.Next(0, drivetrains.Length)], // z. B. 0: FWD, 1: AWD
                             ImagePath = $"images/{brands[b].ToLower()}_{model.Name.ToLower().Replace(" ", "")}_{trimNames[b][m][t].ToLower().Replace(" ", "")}.png",
-                            Cars = new List<Car>()
                         };
 
                         for (int c = 0; c < 5; c++) // 5 Autos pro Trim

--- a/backend/Data/DrivetrainSeeder.cs
+++ b/backend/Data/DrivetrainSeeder.cs
@@ -1,19 +1,19 @@
 ﻿using Microsoft.EntityFrameworkCore;
-using System.ComponentModel.DataAnnotations;
+using Microsoft.OpenApi.Attributes;
 
 namespace SmartContractVehicle.Data;
 public enum Drivetrains
 {
-    [Display(Name = "Front-Wheel Drive (FWD)")]
+    [Display("Front-Wheel Drive (FWD)")]
     FrontWheelDrive = 1,
 
-    [Display(Name = "Rear-Wheel Drive (RWD)")]
+    [Display("Rear-Wheel Drive (RWD)")]
     RearWheelDrive = 2,
 
-    [Display(Name = "All-Wheel Drive (AWD)")]
+    [Display("All-Wheel Drive (AWD)")]
     AllWheelDrive = 3,
 
-    [Display(Name = "Four-Wheel Drive (4WD)")]
+    [Display("Four-Wheel Drive (4WD)")]
     FourWheelDrive = 4
 }
 

--- a/backend/Data/FuelTypeSeeder.cs
+++ b/backend/Data/FuelTypeSeeder.cs
@@ -1,45 +1,45 @@
 ﻿using Microsoft.EntityFrameworkCore;
-using System.ComponentModel.DataAnnotations;
+using Microsoft.OpenApi.Attributes;
 
 namespace SmartContractVehicle.Data;
 
 [Flags]
 public enum FuelTypes
 {
-    [Display(Name = "None")]
+    [Display("None")]
     None = 0,
 
-    [Display(Name = "Gasoline")]
+    [Display("Gasoline")]
     Gasoline = 1 << 0,           // 1
 
-    [Display(Name = "Diesel")]
+    [Display("Diesel")]
     Diesel = 1 << 1,             // 2
 
-    [Display(Name = "Flex Fuel")]
+    [Display("Flex Fuel")]
     FlexFuel = 1 << 2,           // 4
 
-    [Display(Name = "Electric")]
+    [Display("Electric")]
     Electric = 1 << 3,           // 8
 
-    [Display(Name = "Hybrid")]
+    [Display("Hybrid")]
     Hybrid = 1 << 4,             // 16
 
-    [Display(Name = "Plug-in Hybrid")]
+    [Display("Plug-in Hybrid")]
     PlugInHybrid = 1 << 5,       // 32
 
-    [Display(Name = "Hydrogen")]
+    [Display("Hydrogen")]
     Hydrogen = 1 << 6,           // 64
 
-    [Display(Name = "Compressed Natural Gas (CNG)")]
+    [Display("Compressed Natural Gas (CNG)")]
     CompressedNaturalGas = 1 << 7,  // 128
 
-    [Display(Name = "Liquefied Petroleum Gas (LPG)")]
+    [Display("Liquefied Petroleum Gas (LPG)")]
     LiquefiedPetroleumGas = 1 << 8, // 256
 
-    [Display(Name = "Biodiesel")]
+    [Display("Biodiesel")]
     Biodiesel = 1 << 9,          // 512
 
-    [Display(Name = "Ethanol")]
+    [Display("Ethanol")]
     Ethanol = 1 << 10            // 1024
 }
 

--- a/backend/Model/AutomotiveCompany.cs
+++ b/backend/Model/AutomotiveCompany.cs
@@ -8,7 +8,7 @@ namespace SmartContractVehicle.Model
         public Guid Id { get; set; } = Guid.NewGuid();
         public required string Name { get; set; }
 
-        public required ICollection<VehicleModel> Models { get; set; }
+        public virtual ICollection<VehicleModel> Models { get; set; }
 
         public string ImagePath { get; set; } // This should be a path to the file with the Logo of this Company (optional)
     }

--- a/backend/Model/Car.cs
+++ b/backend/Model/Car.cs
@@ -13,9 +13,9 @@ namespace SmartContractVehicle.Model
 
         public required string VIN { get; set; }
 
-        public required User Owner { get; set; }
+        public virtual User Owner { get; set; }
 
-        public required VehicleTrim Trim { get; set; }
+        public virtual VehicleTrim Trim { get; set; }
 
         [Column(TypeName = "geography")]
         public required Point CurrentPosition { get; set; }

--- a/backend/Model/User.cs
+++ b/backend/Model/User.cs
@@ -16,7 +16,7 @@ namespace SmartContractVehicle.Model
 
         public bool IsLessor { get; set; } = false;
 
-        public ICollection<Car>? Cars { get; set; }
+        public virtual ICollection<Car>? Cars { get; set; }
 
 /*
         [Required, DataType(DataType.Date)]

--- a/backend/Model/VehicleModel.cs
+++ b/backend/Model/VehicleModel.cs
@@ -11,9 +11,9 @@ namespace SmartContractVehicle.Model
 
         public required string Name { get; set; }
 
-        public required AutomotiveCompany Producer { get; set; }
+        public virtual AutomotiveCompany Producer { get; set; }
 
-        public required ICollection<VehicleTrim> Trims { get; set; }
+        public virtual ICollection<VehicleTrim> Trims { get; set; }
 
     }
 }

--- a/backend/Model/VehicleTrim.cs
+++ b/backend/Model/VehicleTrim.cs
@@ -11,13 +11,13 @@ namespace SmartContractVehicle.Model
 
         public required string Name { get; set; }
 
-        public required VehicleModel Model { get; set; }
+        public virtual VehicleModel Model { get; set; }
 
-        public required ICollection<Car> Cars { get; set; }
+        public virtual ICollection<Car> Cars { get; set; }
 
-        public required FuelType Fuel { get; set; }
+        public virtual FuelType Fuel { get; set; }
 
-        public required Drivetrain Drivetrain { get; set; } 
+        public virtual Drivetrain Drivetrain { get; set; } 
 
         public required string ImagePath { get; set; }
     }

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -11,7 +11,9 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Database
 builder.Services.AddDbContext<AppDbContext>(options =>
-    options.UseNpgsql(
+    options
+    .UseLazyLoadingProxies()
+    .UseNpgsql(
         builder.Configuration.GetConnectionString("DefaultConnection"),
         o => o.UseNetTopologySuite()
     )

--- a/backend/SmartContractVehicle.csproj
+++ b/backend/SmartContractVehicle.csproj
@@ -15,6 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="9.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="9.0.5" />
     <PackageReference Include="NetTopologySuite" Version="2.6.0" />
     <PackageReference Include="NetTopologySuite.IO.GeoJSON4STJ" Version="4.0.0" />


### PR DESCRIPTION
Fixes that data has not been loaded if it has not been explicitly loaded itself by inserting a LazyLoaderProxy.

Caution: If an AutoMapper is called, it creates a new query, as the database connection is defined as a singleton, this can cause errors. This can be avoided by mapping to a list, then the database connection is terminated and is free again.

Another feature is that the GeoSpatialQueryTO now has data limitations, which are easy to see as attributes in the class.